### PR TITLE
removed falsehood that is irrelevant to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,6 @@ Covers coordinates, projection and GIS.
 - [Falsehoods About
 Names](https://www.kalzumeus.com/2010/06/17/falsehoods-programmers-believe-about-names/) -
 The article that started it all.
-- [Falsehoods About
-Gender](https://gist.github.com/garbados/f82604ea639e0e47bf44) - Gender is part
-of human identity and has its own subtleties.
 - [Gay Marriage: The Database Engineering Perspective](https://qntm.org/gay) -
 How to store a marriage in a database while addressing most of the falsehoods
 about gender, naming and relationships.


### PR DESCRIPTION
While it's cool and all to acknowledge that some people are not male or female, and that some people are not comfortable with the way they were born; I feel that this Item has no place in a list about **_programmer_** falsehoods.

Perhaps if the list were a a curated list of falsehoods in general, not specific to the programmer niche it would fit, otherwise; what stops other miscellaneous falsehoods from making it to the list? Perhaps someone could submit a PR later including articles explaining that adding salt to water does not make it boil quicker, it would be just as relevant.